### PR TITLE
Submission endpoint cleanup

### DIFF
--- a/app/routes/submission.js
+++ b/app/routes/submission.js
@@ -2,4 +2,7 @@ import Route from '@ember/routing/route';
 import AuthenticateRouteMixin from '../mixins/authenticate-route-mixin';
 
 export default Route.extend(AuthenticateRouteMixin, {
+  beforeModel() {
+    this.transitionTo('submission.new'); // Implicitly aborts the on-going transition.
+  }
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -37,8 +37,8 @@
               <div class="dropdown-header text-center">
                 <strong>Notifications</strong>
               </div>
-              <a class="dropdown-item" href="#"><span class="badge badge-pill badge-danger">1</span>Submssion</a>
-              <a class="dropdown-item" href="#"><span class="badge badge-pill badge-danger">1</span>Submssion</a>
+              <a class="dropdown-item" href="#"><span class="badge badge-pill badge-danger">1</span>submission</a>
+              <a class="dropdown-item" href="#"><span class="badge badge-pill badge-danger">1</span>submission</a>
               <a class="dropdown-item" href="#"><span class="badge badge-pill badge-danger"></span>Change requirements</a>
             </div>
           </li>


### PR DESCRIPTION
Add redirect on /submission 

if the user tries to load a part of the workflow by url it will redirect to the /new route instead of just showing a white page. 